### PR TITLE
Suppress warnings from UglifyJs in Webpack config

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -150,7 +150,7 @@ gulp.task "pages", ->
 gulp.task "scss", ["sprites"], ->
 	gulp.src(projectPath(paths.scss, "*.scss"))
 		#.pipe(sourcemaps.init())
-		.pipe(sass().on("error", sass.logError))
+		.pipe(sass(importer: moduleImporter()).on("error", sass.logError))
 		#.pipe(minifycss(rebase: false))
 		#.pipe(sourcemaps.write("."))
 		.pipe(gulp.dest(buildPath(paths.scss)))

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -112,7 +112,7 @@ webpackConfig =
 
 webpackConfigPlugins = [
 	new webpack.webpack.optimize.DedupePlugin(),
-	new webpack.webpack.optimize.UglifyJsPlugin()
+	new webpack.webpack.optimize.UglifyJsPlugin(compress: warnings: false)
 ]
 
 webpackConfigJavaScript = _.cloneDeep(webpackConfig)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "nunjucks-markdown": "^1.1.0",
     "portfinder": "^0.4.0",
     "pretty-hrtime": "^1.0.0",
+    "sass-module-importer": "^1.0.2",
     "st": "^1.1.0",
     "through2": "^2.0.0",
     "webpack-stream": "^3.1.0"


### PR DESCRIPTION
If you import vendor scripts in your main JS, Uglify fills up the build log with random nitpicks about other people's code. This option turns those warnings off.